### PR TITLE
showcase: tests exposing the close()/disconnect() socket bug

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,60 +1,53 @@
-name: CICD
+name: CI/CD
 
 on:
   push:
     branches:
-      - master
+      - '**'
+  pull_request:
 
 jobs:
-  test:
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
 
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18]
-
+        node-version: [18, 20, 22, 24]
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: Install Yarn
-        run: npm install -g yarn
-
-      - name: Install dependencies
-        run: yarn install && yarn upgrade
-
-      - name: Test
-        run: yarn test
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
 
   release:
+    name: Release
     runs-on: ubuntu-latest
-
+    needs: [lint, test]
+    if: github.ref == 'refs/heads/master'
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
-
-      - name: Install Yarn
-        run: npm install -g yarn
-
-      - name: Install dependencies
-        run: yarn install && yarn upgrade
-
-      - name: Build typescript
-        run: npm run build
-
-      - name: Release
-        run: npx semantic-release
+          node-version: 22
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: npm run build
+      - run: npx semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-

--- a/test/udp-logging.test.ts
+++ b/test/udp-logging.test.ts
@@ -1,62 +1,212 @@
 import winston from 'winston';
 import { createSocket, Socket } from 'dgram';
+import { AddressInfo } from 'net';
+import os from 'os';
 
 import { UDPTransport } from '../src';
 
-const TEST_PORT = 55000;
+function receiveMessage(server: Socket, timeoutMs = 2000): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('Timed out waiting for UDP message')), timeoutMs);
+        server.once('message', (msg) => {
+            clearTimeout(timer);
+            resolve(msg.toString());
+        });
+    });
+}
+
 describe('Winston UDP Transport Test', () => {
     let udpServer: Socket;
+    let testPort: number;
 
-    beforeEach(() => {
+    beforeEach((done) => {
         udpServer = createSocket('udp4');
-        udpServer.bind(TEST_PORT);
+        // Bind to port 0 so the OS assigns a free ephemeral port for each test,
+        // preventing cross-test contamination from buffered UDP packets.
+        udpServer.bind(0, () => {
+            testPort = (udpServer.address() as AddressInfo).port;
+            done();
+        });
     });
 
-    afterEach(() => {
-        udpServer.close();
+    afterEach((done) => {
+        udpServer.close(done);
     });
 
-    it('should send log message via UDP transport', async () => {
+    // -------------------------------------------------------------------------
+    // Basic log levels
+    // -------------------------------------------------------------------------
+
+    it('should send an info log message via UDP', async () => {
         const logger = winston.createLogger({
-            transports: [
-                new UDPTransport({
-                    host: '127.0.0.1',
-                    port: TEST_PORT,
-                }),
-            ],
+            transports: [new UDPTransport({ host: '127.0.0.1', port: testPort })],
         });
 
-        const logMessage = 'Test log message';
+        const logMessage = 'Test info message';
         logger.info(logMessage);
 
-        await new Promise<void>((resolve) => {
-            udpServer.on('message', (message) => {
-                const receivedMessage = message.toString();
-                expect(receivedMessage).toContain(logMessage);
-                resolve();
-            });
-        });
+        const received = await receiveMessage(udpServer);
+        expect(received).toContain(logMessage);
     });
 
-    it('should send error message via UDP transport', async () => {
+    it('should send an error log message via UDP', async () => {
         const logger = winston.createLogger({
-            transports: [
-                new UDPTransport({
-                    host: '127.0.0.1',
-                    port: TEST_PORT,
-                }),
-            ],
+            transports: [new UDPTransport({ host: '127.0.0.1', port: testPort })],
         });
 
         const logMessage = 'Test error message';
         logger.error(logMessage);
 
-        await new Promise<void>((resolve) => {
-            udpServer.on('message', (message) => {
-                const receivedMessage = message.toString();
-                expect(receivedMessage).toContain(logMessage);
-                resolve();
-            });
+        const received = await receiveMessage(udpServer);
+        expect(received).toContain(logMessage);
+    });
+
+    it('should send a warn log message via UDP', async () => {
+        const logger = winston.createLogger({
+            transports: [new UDPTransport({ host: '127.0.0.1', port: testPort })],
         });
+
+        logger.warn('Test warn message');
+
+        const received = await receiveMessage(udpServer);
+        expect(received).toContain('Test warn message');
+    });
+
+    // -------------------------------------------------------------------------
+    // Trailing line feed behaviour
+    // -------------------------------------------------------------------------
+
+    it('should append a trailing line feed by default', async () => {
+        // Use printf format so we control the exact output and know it has no trailing newline
+        // before the transport processes it.
+        const rawFormat = winston.format.printf(({ message }) => message as string);
+        const logger = winston.createLogger({
+            format: rawFormat,
+            transports: [new UDPTransport({ host: '127.0.0.1', port: testPort })],
+        });
+
+        logger.info('lf test');
+
+        const received = await receiveMessage(udpServer);
+        expect(received.endsWith(os.EOL)).toBe(true);
+    });
+
+    it('should NOT append a trailing line feed when trailingLineFeed is false', async () => {
+        const rawFormat = winston.format.printf(({ message }) => message as string);
+        const logger = winston.createLogger({
+            format: rawFormat,
+            transports: [
+                new UDPTransport({ host: '127.0.0.1', port: testPort, trailingLineFeed: false }),
+            ],
+        });
+
+        logger.info('no lf test');
+
+        const received = await receiveMessage(udpServer);
+        expect(received).toBe('no lf test');
+        expect(received.endsWith(os.EOL)).toBe(false);
+    });
+
+    it('should use a custom trailingLineFeedChar when provided', async () => {
+        const customChar = '\r\n';
+        const rawFormat = winston.format.printf(({ message }) => message as string);
+        const logger = winston.createLogger({
+            format: rawFormat,
+            transports: [
+                new UDPTransport({
+                    host: '127.0.0.1',
+                    port: testPort,
+                    trailingLineFeed: true,
+                    trailingLineFeedChar: customChar,
+                }),
+            ],
+        });
+
+        logger.info('custom lf test');
+
+        const received = await receiveMessage(udpServer);
+        expect(received.endsWith(customChar)).toBe(true);
+    });
+
+    it('should strip trailing whitespace before appending the line feed char', async () => {
+        const rawFormat = winston.format.printf(({ message }) => `${message}   `);
+        const logger = winston.createLogger({
+            format: rawFormat,
+            transports: [
+                new UDPTransport({
+                    host: '127.0.0.1',
+                    port: testPort,
+                    trailingLineFeed: true,
+                    trailingLineFeedChar: '\n',
+                }),
+            ],
+        });
+
+        logger.info('trailing spaces');
+
+        const received = await receiveMessage(udpServer);
+        // Transport should strip trailing spaces then append exactly \n
+        expect(received).toBe('trailing spaces\n');
+    });
+
+    // -------------------------------------------------------------------------
+    // Silent mode
+    // -------------------------------------------------------------------------
+
+    it('should not send any UDP message when silent is true', async () => {
+        const logger = winston.createLogger({
+            transports: [
+                new UDPTransport({ host: '127.0.0.1', port: testPort, silent: true }),
+            ],
+        });
+
+        logger.info('this should be silent');
+
+        await expect(receiveMessage(udpServer, 300)).rejects.toThrow('Timed out');
+    });
+
+    // -------------------------------------------------------------------------
+    // close() / resource cleanup
+    // -------------------------------------------------------------------------
+
+    it('should close the UDP socket without throwing', () => {
+        const transport = new UDPTransport({ host: '127.0.0.1', port: testPort });
+        expect(() => transport.close()).not.toThrow();
+    });
+
+    it('should be safe to call close() multiple times', () => {
+        const transport = new UDPTransport({ host: '127.0.0.1', port: testPort });
+        transport.close();
+        expect(() => transport.close()).not.toThrow();
+    });
+
+    // -------------------------------------------------------------------------
+    // Callback / event behaviour
+    // -------------------------------------------------------------------------
+
+    it('should invoke the log callback after sending', async () => {
+        const transport = new UDPTransport({ host: '127.0.0.1', port: testPort });
+        const logger = winston.createLogger({ transports: [transport] });
+
+        const callbackCalled = new Promise<void>((resolve) => {
+            transport.once('logged', () => resolve());
+        });
+
+        logger.info('callback test');
+
+        await callbackCalled;
+    });
+
+    it('should emit the "logged" event after a successful send', async () => {
+        const transport = new UDPTransport({ host: '127.0.0.1', port: testPort });
+        const logger = winston.createLogger({ transports: [transport] });
+
+        const logged = new Promise<void>((resolve) => {
+            transport.once('logged', () => resolve());
+        });
+
+        logger.info('event test');
+
+        await expect(logged).resolves.toBeUndefined();
     });
 });


### PR DESCRIPTION
## What this PR demonstrates

This branch adds the expanded test suite **without** the source fix, so you can see the CI failing because of the `close()` / `disconnect()` bug.

### The bug

`UDPTransport.close()` calls `this.client.disconnect()`, but `dgram.Socket` has no `disconnect()` method. The correct method is `close()`.

```ts
// src/udp-transport.ts (buggy)
close(): void {
    this.client.disconnect(); // ❌ throws "Not connected"
}
```

### Failing tests

```
● should close the UDP socket without throwing
  Error: "Not connected"
  at UDPTransport.close (src/udp-transport.ts:38:21)

● should be safe to call close() multiple times
  Error: "Not connected"
  at UDPTransport.close (src/udp-transport.ts:38:21)
```

### The fix

See PR #52 which fixes this (and three other bugs) with `this.client.close()` wrapped in a try/catch for idempotency.

> **Do not merge** — this PR is for demonstration purposes only.

https://claude.ai/code/session_01Au9cfgvecVQBv7tVQuYafH