### PR TITLE
docs: update README CI badge to new workflow files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Github Actions Status](https://github.com/raz6tamir/UDP-transport-winston/actions/workflows/npm-publish.yml/badge.svg)
+![CI](https://github.com/raz6tamir/UDP-transport-winston/actions/workflows/ci.yml/badge.svg)
+![CI/CD](https://github.com/raz6tamir/UDP-transport-winston/actions/workflows/cicd.yml/badge.svg)
 ![npm](https://img.shields.io/npm/v/udp-transport-winston)
 ![NPM](https://img.shields.io/npm/l/udp-transport-winston)
 


### PR DESCRIPTION
Replaces the broken `npm-publish.yml` badge (that workflow was deleted) with two badges:

- **CI** — `ci.yml`, runs on every branch push
- **CI/CD** — `cicd.yml`, runs on master push (lint + test + release)

https://claude.ai/code/session_01Au9cfgvecVQBv7tVQuYafH